### PR TITLE
ack command provided in ack-grep 2.14-4

### DIFF
--- a/tt/install.ttml
+++ b/tt/install.ttml
@@ -123,6 +123,8 @@
     <p>
     your ack will be called "ack-grep", which is 167% more characters
     to type per invocation.  This is tragic for your poor fingers.
+    Luckily, latest releases of "ack-grep" package provide both "ack"
+    and "ack-grep" commands.
     </p>
 
     <p>


### PR DESCRIPTION
I just found out that `act` command is provided by latest versions of `ack-grep` package in Debian-derived distros. Version 2.14-4 is already available in Debian jessie and Ubuntu vivid.
